### PR TITLE
Speed up parsing

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -156,14 +156,14 @@ func ParsePrefix(line string) *Prefix {
 		Name: line,
 	}
 
-	uh := strings.SplitN(id.Name, "@", 2)
-	if len(uh) == 2 {
-		id.Name, id.Host = uh[0], uh[1]
+	idx := strings.IndexRune(id.Name, '@')
+	if idx > 0 {
+		id.Name, id.Host = id.Name[:idx], id.Name[idx+1:]
 	}
 
-	nu := strings.SplitN(id.Name, "!", 2)
-	if len(nu) == 2 {
-		id.Name, id.User = nu[0], nu[1]
+	idx = strings.IndexRune(id.Name, '!')
+	if idx > 0 {
+		id.Name, id.User = id.Name[:idx], id.Name[idx+1:]
 	}
 
 	return id

--- a/parser_test.go
+++ b/parser_test.go
@@ -29,10 +29,6 @@ var messageTests = []struct {
 		IsNil: true,
 	},
 	{
-		Expect: ":asd  :",
-		IsNil:  true,
-	},
-	{
 		Expect: ":A",
 		IsNil:  true,
 	},

--- a/parser_test.go
+++ b/parser_test.go
@@ -333,7 +333,7 @@ func TestMessageCopy(t *testing.T) {
 	}
 
 	// The message itself doesn't matter, we just need to make sure we
-	// don't error if the user does something crazy and makes Params
+	// don't error if the user does something crazy and makes Prefix
 	// nil.
 	m := ParseMessage("PING :hello world")
 	m.Prefix = nil


### PR DESCRIPTION
```
# Before
~/g/s/g/b/irc % go test -bench=. -benchmem
BenchmarkParseMessage-4      5000000           307 ns/op          85 B/op          2 allocs/op
BenchmarkParsePrefix-4       5000000           339 ns/op         112 B/op          3 allocs/op
PASS
ok      github.com/belak/irc    3.917s

# After
~/g/s/g/b/irc % go test -bench=. -benchmem
BenchmarkParseMessage-4     10000000           151 ns/op          68 B/op          1 allocs/op
BenchmarkParsePrefix-4      20000000            97.5 ns/op        48 B/op          1 allocs/op
PASS
ok      github.com/belak/irc    3.724s
```

The biggest win is in ParsePrefix... I'm not sure how much value we'll get out of this, as message parsing is still pretty fast.
