### PR TITLE
Add missing Client.FromChannel

### DIFF
--- a/client.go
+++ b/client.go
@@ -105,3 +105,15 @@ func (c *Client) Run() error {
 func (c *Client) CurrentNick() string {
 	return c.currentNick
 }
+
+// FromChannel takes a Message representing a PRIVMSG and returns if that
+// message came from a channel or directly from a user.
+func (c *Client) FromChannel(m *Message) bool {
+	if len(m.Params) < 1 {
+		return false
+	}
+
+	// The first param is the target, so if this doesn't match the current nick,
+	// the message came from a channel.
+	return m.Params[0] != c.currentNick
+}

--- a/client_test.go
+++ b/client_test.go
@@ -154,4 +154,13 @@ func TestClientHandler(t *testing.T) {
 			Params:  []string{"\x01VERSION"},
 		},
 	}, handler.Messages())
+
+	m := MustParseMessage("PRIVMSG test_nick :hello world")
+	assert.False(t, c.FromChannel(m))
+
+	m = MustParseMessage("PRIVMSG #a_channel :hello world")
+	assert.True(t, c.FromChannel(m))
+
+	m = MustParseMessage("PING")
+	assert.False(t, c.FromChannel(m))
 }


### PR DESCRIPTION
This is needed for some seabird improvements and is a large improvement over Message.FromChannel as it's more accurate, yet doesn't require guessing using isupport.