### PR TITLE
Add support for a ping loop and connection timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - rm ./testcases/*.go
 
 script:
-  - gometalinter --fast ./... -D gas --cyclo-over=12
+  - gometalinter --fast ./... -D gas
   - go test -race -v ./...
   - go test -covermode=count -coverprofile=profile.cov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - rm ./testcases/*.go
 
 script:
-  - gometalinter --fast ./... -D gas
+  - gometalinter --fast ./... -D gas --cyclo-over=12
   - go test -race -v ./...
   - go test -covermode=count -coverprofile=profile.cov
 

--- a/client.go
+++ b/client.go
@@ -30,7 +30,10 @@ var clientFilters = map[string]func(*Client, *Message){
 	},
 	"PONG": func(c *Client, m *Message) {
 		if c.incomingPongChan != nil {
-			c.incomingPongChan <- m.Trailing()
+			select {
+			case c.incomingPongChan <- m.Trailing():
+			default:
+			}
 		}
 	},
 	"PRIVMSG": func(c *Client, m *Message) {

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package irc
 
 import (
 	"io"
-	"net"
 	"sync"
 	"time"
 )
@@ -54,6 +53,8 @@ type ClientConfig struct {
 
 	// Connection settings
 	PingFrequency time.Duration
+	ReadTimeout   time.Duration
+	WriteTimeout  time.Duration
 
 	// Handler is used for message dispatching.
 	Handler Handler
@@ -71,19 +72,13 @@ type Client struct {
 
 // NewClient creates a client given an io stream and a client config.
 func NewClient(rwc io.ReadWriter, config ClientConfig) *Client {
-	return &Client{
+	c := &Client{
 		Conn:   NewConn(rwc),
 		config: config,
 	}
-}
-
-// NewNetClient creates a client given net.Conn, optional timeouts, and
-// a client config.
-func NewNetClient(conn net.Conn, readTimeout, writeTimeout time.Duration, config ClientConfig) *Client {
-	return &Client{
-		Conn:   NewNetConn(conn, readTimeout, writeTimeout),
-		config: config,
-	}
+	c.Reader.SetTimeout(config.ReadTimeout)
+	c.Writer.SetTimeout(config.WriteTimeout)
+	return c
 }
 
 // Run starts the main loop for this IRC connection. Note that it may break in

--- a/client.go
+++ b/client.go
@@ -168,7 +168,7 @@ func (c *Client) maybeStartPingLoop(wg *sync.WaitGroup, exiting chan struct{}) {
 				// Each time we get a tick, we send off a ping and start a
 				// goroutine to handle the pong.
 				timestamp := time.Now().Unix()
-				pongChan := make(chan struct{})
+				pongChan := make(chan struct{}, 1)
 				pingHandlers[fmt.Sprintf("%d", timestamp)] = pongChan
 				wg.Add(1)
 				go c.handlePing(timestamp, pongChan, wg, exiting)

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package irc
 
 import (
 	"io"
+	"net"
 	"sync"
 	"time"
 )
@@ -72,6 +73,15 @@ type Client struct {
 func NewClient(rwc io.ReadWriter, config ClientConfig) *Client {
 	return &Client{
 		Conn:   NewConn(rwc),
+		config: config,
+	}
+}
+
+// NewNetClient creates a client given net.Conn, optional timeouts, and
+// a client config.
+func NewNetClient(conn net.Conn, readTimeout, writeTimeout time.Duration, config ClientConfig) *Client {
+	return &Client{
+		Conn:   NewNetConn(conn, readTimeout, writeTimeout),
 		config: config,
 	}
 }

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package irc
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -201,7 +202,7 @@ func (c *Client) handlePing(timestamp int64, pongChan chan struct{}, wg *sync.Wa
 
 	select {
 	case <-timer.C:
-		c.sendError(err)
+		c.sendError(errors.New("Ping Timeout"))
 	case <-pongChan:
 		return
 	case <-exiting:

--- a/client.go
+++ b/client.go
@@ -147,6 +147,8 @@ func (c *Client) maybeStartPingLoop(wg *sync.WaitGroup, errChan chan error, exit
 
 	wg.Add(1)
 
+	c.incomingPongChan = make(chan string, 5)
+
 	// PONG checker
 	go func() {
 		defer wg.Done()

--- a/client_test.go
+++ b/client_test.go
@@ -38,13 +38,13 @@ func TestClient(t *testing.T) {
 		Name: "test_name",
 	}
 
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -52,7 +52,7 @@ func TestClient(t *testing.T) {
 		ExpectLine("PONG :hello world\r\n"),
 	})
 
-	c := runTest(t, config, io.EOF, []TestAction{
+	c := runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -60,7 +60,7 @@ func TestClient(t *testing.T) {
 	})
 	assert.Equal(t, "new_test_nick", c.CurrentNick())
 
-	c = runTest(t, config, io.EOF, []TestAction{
+	c = runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -68,7 +68,7 @@ func TestClient(t *testing.T) {
 	})
 	assert.Equal(t, "new_test_nick", c.CurrentNick())
 
-	c = runTest(t, config, io.EOF, []TestAction{
+	c = runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -77,7 +77,7 @@ func TestClient(t *testing.T) {
 	})
 	assert.Equal(t, "test_nick_", c.CurrentNick())
 
-	c = runTest(t, config, io.EOF, []TestAction{
+	c = runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -105,7 +105,7 @@ func TestSendLimit(t *testing.T) {
 	}
 
 	before := time.Now()
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -121,7 +121,7 @@ func TestSendLimit(t *testing.T) {
 	config.SendBurst = 0
 
 	before = time.Now()
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -143,7 +143,7 @@ func TestClientHandler(t *testing.T) {
 		Handler: handler,
 	}
 
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -159,7 +159,7 @@ func TestClientHandler(t *testing.T) {
 	}, handler.Messages())
 
 	// Ensure CTCP messages are parsed
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -176,7 +176,7 @@ func TestClientHandler(t *testing.T) {
 
 	// CTCP Regression test for PR#47
 	// Proper CTCP should start AND end in \x01
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -222,7 +222,7 @@ func TestPingLoop(t *testing.T) {
 	var lastPing *Message
 
 	// Successful ping
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -238,7 +238,7 @@ func TestPingLoop(t *testing.T) {
 	})
 
 	// Ping timeout
-	runTest(t, config, errors.New("Ping Timeout"), []TestAction{
+	runClientTest(t, config, errors.New("Ping Timeout"), []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -251,7 +251,7 @@ func TestPingLoop(t *testing.T) {
 	})
 
 	// Exit in the middle of handling a ping
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -264,7 +264,7 @@ func TestPingLoop(t *testing.T) {
 
 	// This one is just for coverage, so we know we're hitting the
 	// branch that drops extra pings.
-	runTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),

--- a/client_test.go
+++ b/client_test.go
@@ -270,12 +270,13 @@ func TestPingLoop(t *testing.T) {
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
 
-		// It's a buffered channel of 5, so we want to send 6 of them
+		// It's a buffered channel of 5, so we want to send at least 6 of them
 		SendLine("PONG :hello 1\r\n"),
 		SendLine("PONG :hello 2\r\n"),
 		SendLine("PONG :hello 3\r\n"),
 		SendLine("PONG :hello 4\r\n"),
 		SendLine("PONG :hello 5\r\n"),
 		SendLine("PONG :hello 6\r\n"),
+		SendLine("PONG :hello 7\r\n"),
 	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -261,4 +261,21 @@ func TestPingLoop(t *testing.T) {
 			lastPing = m
 		}),
 	})
+
+	// This one is just for coverage, so we know we're hitting the
+	// branch that drops extra pings.
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("001 :hello_world\r\n"),
+
+		// It's a buffered channel of 5, so we want to send 6 of them
+		SendLine("PONG :hello 1\r\n"),
+		SendLine("PONG :hello 2\r\n"),
+		SendLine("PONG :hello 3\r\n"),
+		SendLine("PONG :hello 4\r\n"),
+		SendLine("PONG :hello 5\r\n"),
+		SendLine("PONG :hello 6\r\n"),
+	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,8 @@
 package irc
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -29,72 +31,58 @@ func (th *TestHandler) Messages() []*Message {
 func TestClient(t *testing.T) {
 	t.Parallel()
 
-	rwc := newTestReadWriteCloser()
 	config := ClientConfig{
 		Nick: "test_nick",
 		Pass: "test_pass",
 		User: "test_user",
 		Name: "test_name",
 	}
-	c := NewClient(rwc, config)
-	err := c.Run()
-	assert.Equal(t, io.EOF, err)
 
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 
-	rwc.server.WriteString("PING :hello world\r\n")
-	err = c.Run()
-	assert.Equal(t, io.EOF, err)
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
-		"PONG :hello world",
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("PING :hello world\r\n"),
+		ExpectLine("PONG :hello world\r\n"),
 	})
 
-	rwc.server.WriteString(":test_nick NICK :new_test_nick\r\n")
-	err = c.Run()
-	assert.Equal(t, io.EOF, err)
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
+	c := runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine(":test_nick NICK :new_test_nick\r\n"),
 	})
 	assert.Equal(t, "new_test_nick", c.CurrentNick())
 
-	rwc.server.WriteString("001 :new_test_nick\r\n")
-	err = c.Run()
-	assert.Equal(t, io.EOF, err)
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
+	c = runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("001 :new_test_nick\r\n"),
 	})
 	assert.Equal(t, "new_test_nick", c.CurrentNick())
 
-	rwc.server.WriteString("433\r\n")
-	err = c.Run()
-	assert.Equal(t, io.EOF, err)
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
-		"NICK :test_nick_",
+	c = runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("433\r\n"),
+		ExpectLine("NICK :test_nick_\r\n"),
 	})
 	assert.Equal(t, "test_nick_", c.CurrentNick())
 
-	rwc.server.WriteString("437\r\n")
-	err = c.Run()
-	assert.Equal(t, io.EOF, err)
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
-		"NICK :test_nick_",
+	c = runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("437\r\n"),
+		ExpectLine("NICK :test_nick_\r\n"),
 	})
 	assert.Equal(t, "test_nick_", c.CurrentNick())
 }
@@ -103,7 +91,7 @@ func TestSendLimit(t *testing.T) {
 	t.Parallel()
 
 	handler := &TestHandler{}
-	rwc := newTestReadWriteCloser()
+
 	config := ClientConfig{
 		Nick: "test_nick",
 		Pass: "test_pass",
@@ -116,42 +104,36 @@ func TestSendLimit(t *testing.T) {
 		SendBurst: 2,
 	}
 
-	rwc.server.WriteString("001 :hello_world\r\n")
-	c := NewClient(rwc, config)
-
 	before := time.Now()
-	err := c.Run()
-	assert.Equal(t, io.EOF, err)
-	assert.WithinDuration(t, before, time.Now(), 50*time.Millisecond)
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("001 :hello_world\r\n"),
 	})
+	assert.WithinDuration(t, before, time.Now(), 50*time.Millisecond)
 
 	// This last test isn't really a test. It's being used to make sure we
 	// hit the branch which handles dropping ticks if the buffered channel is
 	// full.
-	rwc.server.WriteString("001 :hello world\r\n")
 	handler.delay = 20 * time.Millisecond // Sleep for 20ms when we get the 001 message
-	c.config.SendLimit = 10 * time.Millisecond
-	c.config.SendBurst = 0
+	config.SendLimit = 10 * time.Millisecond
+	config.SendBurst = 0
+
 	before = time.Now()
-	err = c.Run()
-	assert.Equal(t, io.EOF, err)
-	assert.WithinDuration(t, before, time.Now(), 60*time.Millisecond)
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("001 :hello_world\r\n"),
 	})
+	assert.WithinDuration(t, before, time.Now(), 60*time.Millisecond)
 }
 
 func TestClientHandler(t *testing.T) {
 	t.Parallel()
 
 	handler := &TestHandler{}
-	rwc := newTestReadWriteCloser()
 	config := ClientConfig{
 		Nick: "test_nick",
 		Pass: "test_pass",
@@ -161,17 +143,12 @@ func TestClientHandler(t *testing.T) {
 		Handler: handler,
 	}
 
-	rwc.server.WriteString("001 :hello_world\r\n")
-	c := NewClient(rwc, config)
-	err := c.Run()
-	assert.Equal(t, io.EOF, err)
-
-	testLines(t, rwc, []string{
-		"PASS :test_pass",
-		"NICK :test_nick",
-		"USER test_user 0.0.0.0 0.0.0.0 :test_name",
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("001 :hello_world\r\n"),
 	})
-
 	assert.EqualValues(t, []*Message{
 		{
 			Tags:    Tags{},
@@ -182,9 +159,12 @@ func TestClientHandler(t *testing.T) {
 	}, handler.Messages())
 
 	// Ensure CTCP messages are parsed
-	rwc.server.WriteString(":world PRIVMSG :\x01VERSION\x01\r\n")
-	err = c.Run()
-	assert.Equal(t, io.EOF, err)
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine(":world PRIVMSG :\x01VERSION\x01\r\n"),
+	})
 	assert.EqualValues(t, []*Message{
 		{
 			Tags:    Tags{},
@@ -196,9 +176,12 @@ func TestClientHandler(t *testing.T) {
 
 	// CTCP Regression test for PR#47
 	// Proper CTCP should start AND end in \x01
-	rwc.server.WriteString(":world PRIVMSG :\x01VERSION\r\n")
-	err = c.Run()
-	assert.Equal(t, io.EOF, err)
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine(":world PRIVMSG :\x01VERSION\r\n"),
+	})
 	assert.EqualValues(t, []*Message{
 		{
 			Tags:    Tags{},
@@ -207,7 +190,12 @@ func TestClientHandler(t *testing.T) {
 			Params:  []string{"\x01VERSION"},
 		},
 	}, handler.Messages())
+}
 
+func TestFromChannel(t *testing.T) {
+	t.Parallel()
+
+	c := Client{currentNick: "test_nick"}
 	m := MustParseMessage("PRIVMSG test_nick :hello world")
 	assert.False(t, c.FromChannel(m))
 
@@ -216,4 +204,61 @@ func TestClientHandler(t *testing.T) {
 
 	m = MustParseMessage("PING")
 	assert.False(t, c.FromChannel(m))
+}
+
+func TestPingLoop(t *testing.T) {
+	t.Parallel()
+
+	config := ClientConfig{
+		Nick: "test_nick",
+		Pass: "test_pass",
+		User: "test_user",
+		Name: "test_name",
+
+		PingFrequency: 20 * time.Millisecond,
+		PingTimeout:   5 * time.Millisecond,
+	}
+
+	var lastPing *Message
+
+	// Successful ping
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("001 :hello_world\r\n"),
+		Delay(20 * time.Millisecond),
+		LineFunc(func(m *Message) {
+			lastPing = m
+		}),
+		SendFunc(func() string {
+			return fmt.Sprintf("PONG :%s\r\n", lastPing.Trailing())
+		}),
+		Delay(10 * time.Millisecond),
+	})
+
+	// Ping timeout
+	runTest(t, config, errors.New("Ping Timeout"), []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("001 :hello_world\r\n"),
+		Delay(20 * time.Millisecond),
+		LineFunc(func(m *Message) {
+			lastPing = m
+		}),
+		Delay(20 * time.Millisecond),
+	})
+
+	// Exit in the middle of handling a ping
+	runTest(t, config, io.EOF, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("001 :hello_world\r\n"),
+		Delay(20 * time.Millisecond),
+		LineFunc(func(m *Message) {
+			lastPing = m
+		}),
+	})
 }

--- a/conn.go
+++ b/conn.go
@@ -41,7 +41,8 @@ func NewWriter(w io.Writer) *Writer {
 
 // SetTimeout allows you to set the write timeout for the next call to Write.
 // Note that it is undefined behavior to call this while a call to Write is
-// happening.
+// happening. Additionally, this is only effective if a net.Conn was passed into
+// NewWriter.
 func (w *Writer) SetTimeout(timeout time.Duration) {
 	w.timeout = timeout
 }
@@ -105,7 +106,8 @@ func NewReader(r io.Reader) *Reader {
 
 // SetTimeout allows you to set the read timeout for the next call to
 // ReadMessage. Note that it is undefined behavior to call this while
-// a call to ReadMessage is happening.
+// a call to ReadMessage is happening. Additionally, this is only
+// effective if a net.Conn is passed into NewReader.
 func (r *Reader) SetTimeout(timeout time.Duration) {
 	r.timeout = timeout
 }

--- a/conn.go
+++ b/conn.go
@@ -17,13 +17,18 @@ type Conn struct {
 
 // NewConn creates a new Conn
 func NewConn(rw io.ReadWriter) *Conn {
-	// Create the client
-	c := &Conn{
+	return &Conn{
 		NewReader(rw),
 		NewWriter(rw),
 	}
+}
 
-	return c
+// NewNetConn creates a Conn with optional timeouts
+func NewNetConn(conn net.Conn, readTimeout, writeTimeout time.Duration) *Conn {
+	return &Conn{
+		NewNetReader(conn, readTimeout),
+		NewNetWriter(conn, writeTimeout),
+	}
 }
 
 // Writer is the outgoing side of a connection.

--- a/conn_test.go
+++ b/conn_test.go
@@ -19,13 +19,6 @@ func (ew *errorWriter) Write([]byte) (int, error) {
 type readWriteCloser struct {
 	io.Reader
 	io.Writer
-	io.Closer
-}
-
-type nilCloser struct{}
-
-func (nc *nilCloser) Close() error {
-	return nil
 }
 
 type testReadWriteCloser struct {
@@ -84,7 +77,6 @@ func TestWriteMessageError(t *testing.T) {
 	rw := readWriteCloser{
 		&bytes.Buffer{},
 		&errorWriter{},
-		&nilCloser{},
 	}
 
 	c := NewConn(rw)

--- a/conn_test.go
+++ b/conn_test.go
@@ -41,11 +41,6 @@ func (t *testReadWriteCloser) Write(p []byte) (int, error) {
 	return t.client.Write(p)
 }
 
-// Ensure we can close the thing
-func (t *testReadWriteCloser) Close() error {
-	return nil
-}
-
 func testReadMessage(t *testing.T, c *Conn) *Message {
 	m, err := c.ReadMessage()
 	assert.NoError(t, err)

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,178 @@
+package irc
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAction is used to execute an action during a stream test. If a
+// non-nil error is returned the test will be failed.
+type TestAction func(t *testing.T, c *Client, rw *testReadWriter)
+
+func SendLine(output string) TestAction {
+	return func(t *testing.T, c *Client, rw *testReadWriter) {
+		// First we send the message
+		select {
+		case rw.readChan <- output:
+		case <-rw.exiting:
+			assert.Fail(t, "Failed to send")
+		}
+
+		// Now we wait for the buffer to be emptied
+		select {
+		case <-rw.readEmptyChan:
+		case <-rw.exiting:
+			assert.Fail(t, "Failed to send whole message")
+		}
+	}
+}
+
+func SendFunc(cb func() string) TestAction {
+	return func(t *testing.T, c *Client, rw *testReadWriter) {
+		SendLine(cb())(t, c, rw)
+	}
+}
+
+func LineFunc(cb func(m *Message)) TestAction {
+	return func(t *testing.T, c *Client, rw *testReadWriter) {
+		select {
+		case line := <-rw.writeChan:
+			cb(MustParseMessage(line))
+		case <-time.After(1 * time.Second):
+			assert.Fail(t, "LineFunc timeout")
+		case <-rw.exiting:
+		}
+	}
+}
+
+func ExpectLine(input string) TestAction {
+	return ExpectLineWithTimeout(input, 1*time.Second)
+}
+
+func ExpectLineWithTimeout(input string, timeout time.Duration) TestAction {
+	return func(t *testing.T, c *Client, rw *testReadWriter) {
+		select {
+		case line := <-rw.writeChan:
+			assert.Equal(t, input, line)
+		case <-time.After(timeout):
+			assert.Fail(t, "ExpectLine timeout on %s", input)
+		case <-rw.exiting:
+		}
+	}
+}
+
+func Delay(delay time.Duration) TestAction {
+	return func(t *testing.T, c *Client, rw *testReadWriter) {
+		select {
+		case <-time.After(delay):
+		case <-rw.exiting:
+		}
+	}
+}
+
+type testReadWriter struct {
+	actions          []TestAction
+	queuedWriteError error
+	writeChan        chan string
+	queuedReadError  error
+	readChan         chan string
+	readEmptyChan    chan struct{}
+	exiting          chan struct{}
+	clientDone       chan struct{}
+	serverBuffer     bytes.Buffer
+}
+
+func (rw *testReadWriter) Read(buf []byte) (int, error) {
+	if rw.queuedReadError != nil {
+		err := rw.queuedReadError
+		rw.queuedReadError = nil
+		return 0, err
+	}
+
+	// If there's data left in the buffer, we want to use that first.
+	if rw.serverBuffer.Len() > 0 {
+		s, err := rw.serverBuffer.Read(buf)
+		if err == io.EOF {
+			err = nil
+		}
+		return s, err
+	}
+
+	select {
+	case rw.readEmptyChan <- struct{}{}:
+	default:
+	}
+
+	// Read from server. We're either waiting for this whole test to
+	// finish or for data to come in from the server buffer. We expect
+	// only one read to be happening at once.
+	select {
+	case data := <-rw.readChan:
+		rw.serverBuffer.WriteString(data)
+		s, err := rw.serverBuffer.Read(buf)
+		if err == io.EOF {
+			err = nil
+		}
+		return s, err
+	case <-rw.exiting:
+		return 0, io.EOF
+	}
+}
+
+func (rw *testReadWriter) Write(buf []byte) (int, error) {
+	if rw.queuedWriteError != nil {
+		err := rw.queuedWriteError
+		rw.queuedWriteError = nil
+		return 0, err
+	}
+
+	// Write to server. We can cheat with this because we know things
+	// will be written a line at a time.
+	select {
+	case rw.writeChan <- string(buf):
+		return len(buf), nil
+	case <-rw.exiting:
+		return 0, errors.New("Connection closed")
+	}
+}
+
+func runTest(t *testing.T, cc ClientConfig, expectedErr error, actions []TestAction) *Client {
+	rw := &testReadWriter{
+		actions:       actions,
+		writeChan:     make(chan string),
+		readChan:      make(chan string),
+		readEmptyChan: make(chan struct{}, 1),
+		exiting:       make(chan struct{}),
+		clientDone:    make(chan struct{}),
+	}
+
+	c := NewClient(rw, cc)
+
+	go func() {
+		err := c.Run()
+		assert.Equal(t, expectedErr, err)
+		close(rw.clientDone)
+	}()
+
+	// Perform each of the actions
+	for _, action := range rw.actions {
+		action(t, c, rw)
+	}
+
+	// TODO: Make sure there are no more incoming messages
+
+	// Ask everything to shut down and wait for the client to stop.
+	close(rw.exiting)
+	select {
+	case <-rw.clientDone:
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "Timeout in client shutdown")
+	}
+
+	return c
+}


### PR DESCRIPTION
This still needs tests, but this adds support for a ping loop and connection timeouts... which, when used together, should fix the hanging connection timeout issue I've been seeing with seabird.

TODO:

- [x] Add tests
- [x] Shut down the connection if a ping fails to write to the connection