### PR TITLE
Initial support for IRCv3 CAP negotiation

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,47 +52,31 @@ var clientFilters = map[string]func(*Client, *Message){
 			c.currentNick = m.Params[0]
 		}
 	},
-	"CAP": func(c *Client, m *Message) {
-		if c.remainingCapResponses <= 0 || len(m.Params) <= 2 {
-			return
+}
+
+var capHandlers = map[string]func(*Client, *Message){
+	"LS": func(c *Client, m *Message) {
+		for _, key := range strings.Split(m.Trailing(), " ") {
+			cap := c.caps[key]
+			cap.Available = true
+			c.caps[key] = cap
 		}
-
-		switch m.Params[1] {
-		case "LS":
-			for _, key := range strings.Split(m.Trailing(), " ") {
-				cap := c.caps[key]
-				cap.Available = true
-				c.caps[key] = cap
-			}
-			c.remainingCapResponses--
-		case "ACK":
-			for _, key := range strings.Split(m.Trailing(), " ") {
-				cap := c.caps[key]
-				cap.Enabled = true
-				c.caps[key] = cap
-			}
-			c.remainingCapResponses--
-		case "NAK":
-			// If we got a NAK and this REQ was required, we need to bail
-			// with an error.
-			for _, key := range strings.Split(m.Trailing(), " ") {
-				if c.caps[key].Required {
-					c.sendError(fmt.Errorf("CAP %s requested but was rejected", key))
-					return
-				}
-			}
-			c.remainingCapResponses--
+	},
+	"ACK": func(c *Client, m *Message) {
+		for _, key := range strings.Split(m.Trailing(), " ") {
+			cap := c.caps[key]
+			cap.Enabled = true
+			c.caps[key] = cap
 		}
-
-		if c.remainingCapResponses <= 0 {
-			for key, cap := range c.caps {
-				if cap.Required && !cap.Enabled {
-					c.sendError(fmt.Errorf("CAP %s requested but not accepted", key))
-					return
-				}
+	},
+	"NAK": func(c *Client, m *Message) {
+		// If we got a NAK and this REQ was required, we need to bail
+		// with an error.
+		for _, key := range strings.Split(m.Trailing(), " ") {
+			if c.caps[key].Required {
+				c.sendError(fmt.Errorf("CAP %s requested but was rejected", key))
+				return
 			}
-
-			c.Write("CAP END")
 		}
 	},
 }
@@ -141,12 +125,11 @@ type Client struct {
 	config ClientConfig
 
 	// Internal state
-	currentNick           string
-	limiter               chan struct{}
-	incomingPongChan      chan string
-	errChan               chan error
-	caps                  map[string]cap
-	remainingCapResponses int
+	currentNick      string
+	limiter          chan struct{}
+	incomingPongChan chan string
+	errChan          chan error
+	caps             map[string]cap
 }
 
 // NewClient creates a client given an io stream and a client config.
@@ -305,19 +288,45 @@ func (c *Client) CapAvailable(capName string) bool {
 	return c.caps[capName].Available
 }
 
-func (c *Client) maybeStartCapHandshake() error {
-	if len(c.caps) <= 0 {
-		return nil
-	}
-
+func (c *Client) handleCapHandshake() error {
 	c.Write("CAP LS")
-	c.remainingCapResponses = 1 // We count the CAP LS response as a normal response
+	remainingCapResponses := 1 // We count the CAP LS response as a normal response
 	for key, cap := range c.caps {
 		if cap.Requested {
 			c.Writef("CAP REQ :%s", key)
-			c.remainingCapResponses++
+			remainingCapResponses++
 		}
 	}
+
+	for remainingCapResponses > 0 {
+		m, err := c.ReadMessage()
+		if err != nil {
+			return err
+		}
+
+		// If we get ERR_UNKNOWNCOMMAND we should bail out of this loop but not
+		// fail, so if only optional CAPs were requested, we can continue.
+		if m.Command == "421" {
+			break
+		}
+
+		if m.Command != "CAP" || len(m.Params) < 3 {
+			return errors.New("Unexpected command inside CAP handshake")
+		}
+
+		if f, ok := capHandlers[m.Params[1]]; ok {
+			f(c, m)
+			remainingCapResponses--
+		}
+	}
+
+	for key, cap := range c.caps {
+		if cap.Required && !cap.Enabled {
+			return fmt.Errorf("CAP %s requested but not accepted", key)
+		}
+	}
+
+	c.Write("CAP END")
 
 	return nil
 }
@@ -340,26 +349,26 @@ func (c *Client) Run() error {
 		c.Writef("PASS :%s", c.config.Pass)
 	}
 
-	c.maybeStartCapHandshake()
+	if err := c.handleCapHandshake(); err != nil {
+		c.sendError(err)
+	} else {
+		c.Writef("NICK :%s", c.config.Nick)
+		c.Writef("USER %s 0.0.0.0 0.0.0.0 :%s", c.config.User, c.config.Name)
 
-	// This feels wrong because it results in CAP LS, CAP REQ, NICK, USER, CAP
-	// END, but it works and lets us keep the code a bit simpler.
-	c.Writef("NICK :%s", c.config.Nick)
-	c.Writef("USER %s 0.0.0.0 0.0.0.0 :%s", c.config.User, c.config.Name)
+		for {
+			m, err := c.ReadMessage()
+			if err != nil {
+				c.sendError(err)
+				break
+			}
 
-	for {
-		m, err := c.ReadMessage()
-		if err != nil {
-			c.sendError(err)
-			break
-		}
+			if f, ok := clientFilters[m.Command]; ok {
+				f(c, m)
+			}
 
-		if f, ok := clientFilters[m.Command]; ok {
-			f(c, m)
-		}
-
-		if c.config.Handler != nil {
-			c.config.Handler.Handle(c, m)
+			if c.config.Handler != nil {
+				c.config.Handler.Handle(c, m)
+			}
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -46,11 +46,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.True(t, c.CapEnabled("multi-prefix"))
@@ -66,12 +66,12 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		//SendLine("CAP * ACK\r\n"), // Malformed CAP response
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.True(t, c.CapEnabled("multi-prefix"))
@@ -87,11 +87,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
@@ -107,11 +107,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.False(t, c.CapEnabled("multi-prefix"))
@@ -126,8 +126,6 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 	})
@@ -144,8 +142,6 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :\r\n"),
 	})
@@ -167,12 +163,18 @@ func TestClient(t *testing.T) {
 
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("PING :hello world\r\n"),
@@ -181,6 +183,9 @@ func TestClient(t *testing.T) {
 
 	c := runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine(":test_nick NICK :new_test_nick\r\n"),
@@ -189,6 +194,9 @@ func TestClient(t *testing.T) {
 
 	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :new_test_nick\r\n"),
@@ -197,6 +205,9 @@ func TestClient(t *testing.T) {
 
 	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("433\r\n"),
@@ -206,6 +217,9 @@ func TestClient(t *testing.T) {
 
 	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("437\r\n"),
@@ -234,11 +248,14 @@ func TestSendLimit(t *testing.T) {
 	before := time.Now()
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
 	})
-	assert.WithinDuration(t, before, time.Now(), 50*time.Millisecond)
+	assert.WithinDuration(t, before, time.Now(), 60*time.Millisecond)
 
 	// This last test isn't really a test. It's being used to make sure we
 	// hit the branch which handles dropping ticks if the buffered channel is
@@ -250,11 +267,14 @@ func TestSendLimit(t *testing.T) {
 	before = time.Now()
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
 	})
-	assert.WithinDuration(t, before, time.Now(), 60*time.Millisecond)
+	assert.WithinDuration(t, before, time.Now(), 80*time.Millisecond)
 }
 
 func TestClientHandler(t *testing.T) {
@@ -272,6 +292,9 @@ func TestClientHandler(t *testing.T) {
 
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
@@ -288,6 +311,9 @@ func TestClientHandler(t *testing.T) {
 	// Ensure CTCP messages are parsed
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine(":world PRIVMSG :\x01VERSION\x01\r\n"),
@@ -305,6 +331,9 @@ func TestClientHandler(t *testing.T) {
 	// Proper CTCP should start AND end in \x01
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine(":world PRIVMSG :\x01VERSION\r\n"),
@@ -351,6 +380,9 @@ func TestPingLoop(t *testing.T) {
 	// Successful ping
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
@@ -367,6 +399,9 @@ func TestPingLoop(t *testing.T) {
 	// Ping timeout
 	runClientTest(t, config, errors.New("Ping Timeout"), nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
@@ -380,6 +415,9 @@ func TestPingLoop(t *testing.T) {
 	// Exit in the middle of handling a ping
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
@@ -393,6 +431,9 @@ func TestPingLoop(t *testing.T) {
 	// branch that drops extra pings.
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		SendLine("CAP * LS :\r\n"),
+		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),

--- a/client_test.go
+++ b/client_test.go
@@ -46,11 +46,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.True(t, c.CapEnabled("multi-prefix"))
@@ -66,12 +66,12 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		//SendLine("CAP * ACK\r\n"), // Malformed CAP response
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.True(t, c.CapEnabled("multi-prefix"))
@@ -87,11 +87,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
@@ -107,11 +107,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.False(t, c.CapEnabled("multi-prefix"))
@@ -126,6 +126,8 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 	})
@@ -142,6 +144,8 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :\r\n"),
 	})
@@ -149,13 +153,6 @@ func TestCapReq(t *testing.T) {
 	assert.False(t, c.CapEnabled("multi-prefix"))
 	assert.False(t, c.CapAvailable("random-thing"))
 	assert.True(t, c.CapAvailable("multi-prefix"))
-
-	runClientTest(t, config, errors.New("CAP requested after CAP handshake"), func(c *Client) {
-		assert.False(t, c.CapAvailable("random-thing"))
-		assert.False(t, c.CapAvailable("multi-prefix"))
-		c.finishedHandshake = true
-		c.CapRequest("multi-prefix", true)
-	}, []TestAction{})
 }
 
 func TestClient(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -46,11 +46,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.True(t, c.CapEnabled("multi-prefix"))
@@ -66,12 +66,12 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		//SendLine("CAP * ACK\r\n"), // Malformed CAP response
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.True(t, c.CapEnabled("multi-prefix"))
@@ -87,11 +87,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
@@ -107,11 +107,11 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 		ExpectLine("CAP END\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 	assert.False(t, c.CapEnabled("random-thing"))
 	assert.False(t, c.CapEnabled("multi-prefix"))
@@ -126,6 +126,8 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * NAK :multi-prefix\r\n"),
 	})
@@ -142,6 +144,8 @@ func TestCapReq(t *testing.T) {
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("CAP LS\r\n"),
 		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("CAP * LS :multi-prefix\r\n"),
 		SendLine("CAP * ACK :\r\n"),
 	})
@@ -163,18 +167,12 @@ func TestClient(t *testing.T) {
 
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("PING :hello world\r\n"),
@@ -183,9 +181,6 @@ func TestClient(t *testing.T) {
 
 	c := runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine(":test_nick NICK :new_test_nick\r\n"),
@@ -194,9 +189,6 @@ func TestClient(t *testing.T) {
 
 	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :new_test_nick\r\n"),
@@ -205,9 +197,6 @@ func TestClient(t *testing.T) {
 
 	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("433\r\n"),
@@ -217,9 +206,6 @@ func TestClient(t *testing.T) {
 
 	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("437\r\n"),
@@ -248,14 +234,11 @@ func TestSendLimit(t *testing.T) {
 	before := time.Now()
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
 	})
-	assert.WithinDuration(t, before, time.Now(), 60*time.Millisecond)
+	assert.WithinDuration(t, before, time.Now(), 50*time.Millisecond)
 
 	// This last test isn't really a test. It's being used to make sure we
 	// hit the branch which handles dropping ticks if the buffered channel is
@@ -267,14 +250,11 @@ func TestSendLimit(t *testing.T) {
 	before = time.Now()
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
 	})
-	assert.WithinDuration(t, before, time.Now(), 80*time.Millisecond)
+	assert.WithinDuration(t, before, time.Now(), 60*time.Millisecond)
 }
 
 func TestClientHandler(t *testing.T) {
@@ -292,9 +272,6 @@ func TestClientHandler(t *testing.T) {
 
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
@@ -311,9 +288,6 @@ func TestClientHandler(t *testing.T) {
 	// Ensure CTCP messages are parsed
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine(":world PRIVMSG :\x01VERSION\x01\r\n"),
@@ -331,9 +305,6 @@ func TestClientHandler(t *testing.T) {
 	// Proper CTCP should start AND end in \x01
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine(":world PRIVMSG :\x01VERSION\r\n"),
@@ -380,9 +351,6 @@ func TestPingLoop(t *testing.T) {
 	// Successful ping
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
@@ -399,9 +367,6 @@ func TestPingLoop(t *testing.T) {
 	// Ping timeout
 	runClientTest(t, config, errors.New("Ping Timeout"), nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
@@ -415,9 +380,6 @@ func TestPingLoop(t *testing.T) {
 	// Exit in the middle of handling a ping
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),
@@ -431,9 +393,6 @@ func TestPingLoop(t *testing.T) {
 	// branch that drops extra pings.
 	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("CAP LS\r\n"),
-		SendLine("CAP * LS :\r\n"),
-		ExpectLine("CAP END\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 		SendLine("001 :hello_world\r\n"),

--- a/client_test.go
+++ b/client_test.go
@@ -149,6 +149,13 @@ func TestCapReq(t *testing.T) {
 	assert.False(t, c.CapEnabled("multi-prefix"))
 	assert.False(t, c.CapAvailable("random-thing"))
 	assert.True(t, c.CapAvailable("multi-prefix"))
+
+	runClientTest(t, config, errors.New("CAP requested after CAP handshake"), func(c *Client) {
+		assert.False(t, c.CapAvailable("random-thing"))
+		assert.False(t, c.CapAvailable("multi-prefix"))
+		c.finishedHandshake = true
+		c.CapRequest("multi-prefix", true)
+	}, []TestAction{})
 }
 
 func TestClient(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -28,6 +28,129 @@ func (th *TestHandler) Messages() []*Message {
 	return ret
 }
 
+func TestCapReq(t *testing.T) {
+	t.Parallel()
+
+	config := ClientConfig{
+		Nick: "test_nick",
+		Pass: "test_pass",
+		User: "test_user",
+		Name: "test_name",
+	}
+
+	c := runClientTest(t, config, io.EOF, func(c *Client) {
+		assert.False(t, c.CapAvailable("random-thing"))
+		assert.False(t, c.CapAvailable("multi-prefix"))
+		c.CapRequest("multi-prefix", true)
+	}, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		SendLine("CAP * LS :multi-prefix\r\n"),
+		SendLine("CAP * ACK :multi-prefix\r\n"),
+		ExpectLine("CAP END\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+	})
+	assert.False(t, c.CapEnabled("random-thing"))
+	assert.True(t, c.CapEnabled("multi-prefix"))
+	assert.False(t, c.CapAvailable("random-thing"))
+	assert.True(t, c.CapAvailable("multi-prefix"))
+
+	// Malformed CAP responses are ignored
+	c = runClientTest(t, config, io.EOF, func(c *Client) {
+		assert.False(t, c.CapAvailable("random-thing"))
+		assert.False(t, c.CapAvailable("multi-prefix"))
+		c.CapRequest("multi-prefix", true)
+	}, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		SendLine("CAP * LS :multi-prefix\r\n"),
+		//SendLine("CAP * ACK\r\n"), // Malformed CAP response
+		SendLine("CAP * ACK :multi-prefix\r\n"),
+		ExpectLine("CAP END\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+	})
+	assert.False(t, c.CapEnabled("random-thing"))
+	assert.True(t, c.CapEnabled("multi-prefix"))
+	assert.False(t, c.CapAvailable("random-thing"))
+	assert.True(t, c.CapAvailable("multi-prefix"))
+
+	// Additional CAP messages after the start are ignored.
+	c = runClientTest(t, config, io.EOF, func(c *Client) {
+		assert.False(t, c.CapAvailable("random-thing"))
+		assert.False(t, c.CapAvailable("multi-prefix"))
+		c.CapRequest("multi-prefix", true)
+	}, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		SendLine("CAP * LS :multi-prefix\r\n"),
+		SendLine("CAP * ACK :multi-prefix\r\n"),
+		ExpectLine("CAP END\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		SendLine("CAP * NAK :multi-prefix\r\n"),
+	})
+	assert.False(t, c.CapEnabled("random-thing"))
+	assert.True(t, c.CapEnabled("multi-prefix"))
+	assert.False(t, c.CapAvailable("random-thing"))
+	assert.True(t, c.CapAvailable("multi-prefix"))
+
+	c = runClientTest(t, config, io.EOF, func(c *Client) {
+		assert.False(t, c.CapAvailable("random-thing"))
+		assert.False(t, c.CapAvailable("multi-prefix"))
+		c.CapRequest("multi-prefix", false)
+	}, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		SendLine("CAP * LS :multi-prefix\r\n"),
+		SendLine("CAP * NAK :multi-prefix\r\n"),
+		ExpectLine("CAP END\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+	})
+	assert.False(t, c.CapEnabled("random-thing"))
+	assert.False(t, c.CapEnabled("multi-prefix"))
+	assert.False(t, c.CapAvailable("random-thing"))
+	assert.True(t, c.CapAvailable("multi-prefix"))
+
+	c = runClientTest(t, config, errors.New("CAP multi-prefix requested but was rejected"), func(c *Client) {
+		assert.False(t, c.CapAvailable("random-thing"))
+		assert.False(t, c.CapAvailable("multi-prefix"))
+		c.CapRequest("multi-prefix", true)
+	}, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		SendLine("CAP * LS :multi-prefix\r\n"),
+		SendLine("CAP * NAK :multi-prefix\r\n"),
+	})
+	assert.False(t, c.CapEnabled("random-thing"))
+	assert.False(t, c.CapEnabled("multi-prefix"))
+	assert.False(t, c.CapAvailable("random-thing"))
+	assert.True(t, c.CapAvailable("multi-prefix"))
+
+	c = runClientTest(t, config, errors.New("CAP multi-prefix requested but not accepted"), func(c *Client) {
+		assert.False(t, c.CapAvailable("random-thing"))
+		assert.False(t, c.CapAvailable("multi-prefix"))
+		c.CapRequest("multi-prefix", true)
+	}, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("CAP LS\r\n"),
+		ExpectLine("CAP REQ :multi-prefix\r\n"),
+		SendLine("CAP * LS :multi-prefix\r\n"),
+		SendLine("CAP * ACK :\r\n"),
+	})
+	assert.False(t, c.CapEnabled("random-thing"))
+	assert.False(t, c.CapEnabled("multi-prefix"))
+	assert.False(t, c.CapAvailable("random-thing"))
+	assert.True(t, c.CapAvailable("multi-prefix"))
+}
+
 func TestClient(t *testing.T) {
 	t.Parallel()
 
@@ -38,13 +161,13 @@ func TestClient(t *testing.T) {
 		Name: "test_name",
 	}
 
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
 	})
 
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -52,7 +175,7 @@ func TestClient(t *testing.T) {
 		ExpectLine("PONG :hello world\r\n"),
 	})
 
-	c := runClientTest(t, config, io.EOF, []TestAction{
+	c := runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -60,7 +183,7 @@ func TestClient(t *testing.T) {
 	})
 	assert.Equal(t, "new_test_nick", c.CurrentNick())
 
-	c = runClientTest(t, config, io.EOF, []TestAction{
+	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -68,7 +191,7 @@ func TestClient(t *testing.T) {
 	})
 	assert.Equal(t, "new_test_nick", c.CurrentNick())
 
-	c = runClientTest(t, config, io.EOF, []TestAction{
+	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -77,7 +200,7 @@ func TestClient(t *testing.T) {
 	})
 	assert.Equal(t, "test_nick_", c.CurrentNick())
 
-	c = runClientTest(t, config, io.EOF, []TestAction{
+	c = runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -105,7 +228,7 @@ func TestSendLimit(t *testing.T) {
 	}
 
 	before := time.Now()
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -121,7 +244,7 @@ func TestSendLimit(t *testing.T) {
 	config.SendBurst = 0
 
 	before = time.Now()
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -143,7 +266,7 @@ func TestClientHandler(t *testing.T) {
 		Handler: handler,
 	}
 
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -159,7 +282,7 @@ func TestClientHandler(t *testing.T) {
 	}, handler.Messages())
 
 	// Ensure CTCP messages are parsed
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -176,7 +299,7 @@ func TestClientHandler(t *testing.T) {
 
 	// CTCP Regression test for PR#47
 	// Proper CTCP should start AND end in \x01
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -222,7 +345,7 @@ func TestPingLoop(t *testing.T) {
 	var lastPing *Message
 
 	// Successful ping
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -238,7 +361,7 @@ func TestPingLoop(t *testing.T) {
 	})
 
 	// Ping timeout
-	runClientTest(t, config, errors.New("Ping Timeout"), []TestAction{
+	runClientTest(t, config, errors.New("Ping Timeout"), nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -251,7 +374,7 @@ func TestPingLoop(t *testing.T) {
 	})
 
 	// Exit in the middle of handling a ping
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
@@ -264,7 +387,7 @@ func TestPingLoop(t *testing.T) {
 
 	// This one is just for coverage, so we know we're hitting the
 	// branch that drops extra pings.
-	runClientTest(t, config, io.EOF, []TestAction{
+	runClientTest(t, config, io.EOF, nil, []TestAction{
 		ExpectLine("PASS :test_pass\r\n"),
 		ExpectLine("NICK :test_nick\r\n"),
 		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),

--- a/stream_test.go
+++ b/stream_test.go
@@ -26,7 +26,7 @@ func SendLineWithTimeout(output string, timeout time.Duration) TestAction {
 		select {
 		case rw.readChan <- output:
 		case <-waitChan:
-			assert.Fail(t, "SendLine timeout on %s", output)
+			assert.Fail(t, "SendLine send timeout on %s", output)
 			return
 		case <-rw.exiting:
 			assert.Fail(t, "Failed to send")


### PR DESCRIPTION
This is related to #53 

Based on http://ircv3.net/specs/core/capability-negotiation-3.1.html and how some odd servers respond to `CAP ACK` requests.

TODO:

- [x] Clean up code - specifically cyclo complexity of handleCapHandshake
- [x] Answer questions leftover in #53 - Current plan is "yes" so we can re-use the same event-loop.
- [x] Remove the debug c.CapRequest calls
- [x] Remove any debug printf calls
- [x] Tests
- [x] Docs
- [x] Improve/fix error handling when an error is sent in a handler
- [x] ~Handle multi-line CAP LS response~ This is a 3.2 extension which I'm holding off on for now
