### PR TITLE
Stop rewriting CTCP PRIVMSG messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ considered stable enough, a new release will be tagged.
 
 As a result of this, there are multiple import locations.
 
-* `gopkg.in/irc.v1` should be used to develop against the commits
+* `gopkg.in/irc.v2` should be used to develop against the commits
   tagged as stable
 * `github.com/go-irc/irc` should be used to develop against the master branch
 
@@ -86,3 +86,14 @@ func main() {
 	}
 }
 ```
+
+## Major Version Changes
+
+### v1
+
+Initial release
+
+### v2
+
+CTCP messages will no longer be rewritten. The decision was made that this
+library should not rewrite messages.

--- a/client.go
+++ b/client.go
@@ -36,16 +36,6 @@ var clientFilters = map[string]func(*Client, *Message){
 			}
 		}
 	},
-	"PRIVMSG": func(c *Client, m *Message) {
-		// Clean up CTCP stuff so everyone doesn't have to parse it
-		// manually.
-		lastArg := m.Trailing()
-		lastIdx := len(lastArg) - 1
-		if lastIdx > 0 && lastArg[0] == '\x01' && lastArg[lastIdx] == '\x01' {
-			m.Command = "CTCP"
-			m.Params[len(m.Params)-1] = lastArg[1:lastIdx]
-		}
-	},
 	"NICK": func(c *Client, m *Message) {
 		if m.Prefix.Name == c.currentNick && len(m.Params) > 0 {
 			c.currentNick = m.Params[0]

--- a/client_test.go
+++ b/client_test.go
@@ -157,39 +157,6 @@ func TestClientHandler(t *testing.T) {
 			Params:  []string{"hello_world"},
 		},
 	}, handler.Messages())
-
-	// Ensure CTCP messages are parsed
-	runClientTest(t, config, io.EOF, []TestAction{
-		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
-		SendLine(":world PRIVMSG :\x01VERSION\x01\r\n"),
-	})
-	assert.EqualValues(t, []*Message{
-		{
-			Tags:    Tags{},
-			Prefix:  &Prefix{Name: "world"},
-			Command: "CTCP",
-			Params:  []string{"VERSION"},
-		},
-	}, handler.Messages())
-
-	// CTCP Regression test for PR#47
-	// Proper CTCP should start AND end in \x01
-	runClientTest(t, config, io.EOF, []TestAction{
-		ExpectLine("PASS :test_pass\r\n"),
-		ExpectLine("NICK :test_nick\r\n"),
-		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
-		SendLine(":world PRIVMSG :\x01VERSION\r\n"),
-	})
-	assert.EqualValues(t, []*Message{
-		{
-			Tags:    Tags{},
-			Prefix:  &Prefix{Name: "world"},
-			Command: "PRIVMSG",
-			Params:  []string{"\x01VERSION"},
-		},
-	}, handler.Messages())
 }
 
 func TestFromChannel(t *testing.T) {


### PR DESCRIPTION
This is being added to seabird, since we shouldn't rewrite messages at this low of a level