### PR TITLE
Ensure all write errors cause the client to exit

### DIFF
--- a/client.go
+++ b/client.go
@@ -173,6 +173,9 @@ func (c *Client) writeCallback(w *Writer, line string) error {
 	}
 
 	_, err := w.writer.Write([]byte(line + "\r\n"))
+	if err != nil {
+		c.sendError(err)
+	}
 	return err
 }
 
@@ -260,11 +263,7 @@ func (c *Client) maybeStartPingLoop(wg *sync.WaitGroup, exiting chan struct{}) {
 func (c *Client) handlePing(timestamp int64, pongChan chan struct{}, wg *sync.WaitGroup, exiting chan struct{}) {
 	defer wg.Done()
 
-	err := c.Writef("PING :%d", timestamp)
-	if err != nil {
-		c.sendError(err)
-		return
-	}
+	c.Writef("PING :%d", timestamp)
 
 	timer := time.NewTimer(c.config.PingTimeout)
 	defer timer.Stop()

--- a/client_test.go
+++ b/client_test.go
@@ -403,4 +403,15 @@ func TestPingLoop(t *testing.T) {
 		SendLine("PONG :hello 6\r\n"),
 		SendLine("PONG :hello 7\r\n"),
 	})
+
+	// Successful ping with write error
+	runClientTest(t, config, errors.New("test error"), nil, []TestAction{
+		ExpectLine("PASS :test_pass\r\n"),
+		ExpectLine("NICK :test_nick\r\n"),
+		ExpectLine("USER test_user 0.0.0.0 0.0.0.0 :test_name\r\n"),
+		// We queue this up a line early because the next write will happen after the delay.
+		QueueWriteError(errors.New("test error")),
+		SendLine("001 :hello_world\r\n"),
+		Delay(25 * time.Millisecond),
+	})
 }


### PR DESCRIPTION
This allows all errors to cause the connection to close. This ensures that the ping timeout will be able to cause the connection to exit and should fix the issues I've been seeing with the bot hanging when the connection has died.