### PR TITLE
reader: ignore empty messages

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -90,6 +90,8 @@ func NewReader(r io.Reader) *Reader {
 // ReadMessage returns the next message from the stream or an error.
 // It ignores empty messages.
 func (r *Reader) ReadMessage() (msg *Message, err error) {
+	// It's valid for a message to be empty. Clients should ignore these,
+	// so we do to be good citizens.
 	err = ErrZeroLengthMessage
 	for err == ErrZeroLengthMessage {
 		var line string

--- a/conn.go
+++ b/conn.go
@@ -88,16 +88,22 @@ func NewReader(r io.Reader) *Reader {
 }
 
 // ReadMessage returns the next message from the stream or an error.
-func (r *Reader) ReadMessage() (*Message, error) {
-	line, err := r.reader.ReadString('\n')
-	if err != nil {
-		return nil, err
-	}
+// It ignores empty messages.
+func (r *Reader) ReadMessage() (msg *Message, err error) {
+	err = ErrZeroLengthMessage
+	for err == ErrZeroLengthMessage {
+		var line string
+		line, err = r.reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
 
-	if r.DebugCallback != nil {
-		r.DebugCallback(line)
-	}
+		if r.DebugCallback != nil {
+			r.DebugCallback(line)
+		}
 
-	// Parse the message from our line
-	return ParseMessage(line)
+		// Parse the message from our line
+		msg, err = ParseMessage(line)
+	}
+	return msg, err
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -120,7 +120,7 @@ func TestConn(t *testing.T) {
 	rwc.server.WriteString(":invalid_message\r\n")
 	_, err := c.ReadMessage()
 	assert.Equal(t, ErrMissingDataAfterPrefix, err)
-	
+
 	// Ensure empty messages are ignored
 	m = MustParseMessage("001 test_nick")
 	rwc.server.WriteString("\r\n" + m.String() + "\r\n")

--- a/conn_test.go
+++ b/conn_test.go
@@ -120,6 +120,12 @@ func TestConn(t *testing.T) {
 	rwc.server.WriteString(":invalid_message\r\n")
 	_, err := c.ReadMessage()
 	assert.Equal(t, ErrMissingDataAfterPrefix, err)
+	
+	// Ensure empty messages are ignored
+	m = MustParseMessage("001 test_nick")
+	rwc.server.WriteString("\r\n" + m.String() + "\r\n")
+	m2 = testReadMessage(t, c)
+	assert.EqualValues(t, m, m2, "Message returned by client did not match input")
 
 	// This is an odd one... if there wasn't any output, it'll hit
 	// EOF, so we expect an error here so we can test an error


### PR DESCRIPTION
The spec [0] says empty messages should be ignored instead of throwing
an error.

[0] https://tools.ietf.org/html/rfc2812#section-2.3.1