### PR TITLE
Add facility to schedule recurring callbacks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module gopkg.in/irc.v3
 go 1.13
 
 require (
-	github.com/stretchr/testify v1.4.0
-	gopkg.in/yaml.v2 v2.2.8
+	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/irc.v3
+module github.com/nathanvy/irc
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/nathanvy/irc
+module github.com/nathanvy/irc/v5
 
-go 1.13
+go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
Further to my comment in [this issue](https://github.com/go-irc/irc/issues/86), I decided to just start hacking and see how it turned out.  In brief:

1. I added a new field to the ClientConfig struct that holds a slice of `(function, time.duration)` tuples
2. I patched `RunContext()` to foreach through the slice and spawn a new goroutine with an associated ticker for each tuple
3. The goroutine calls a callback and passes a pointer to the Client so that it's convenient to interface with the library

**Rationale**

My particular use case for this is in IOT applications.  I find that, for devices with a TCP/IP stack, IRC is a convenient and easy way to get data off of IOT/embedded devices and out to wherever it's needed.  I wanted a way to periodically poll sensors or something of that nature, and then have the results posted to IRC for consumption by other services.

Hopefully this PR is useful to someone with a similar use case.