### PR TITLE
Remove NUL, CR and LF from messages before parsing

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -75,6 +75,11 @@ func TestMessageParam(t *testing.T) {
 	assert.Equal(t, m.Param(0), "test")
 	assert.Equal(t, m.Param(-1), "")
 	assert.Equal(t, m.Param(2), "")
+
+	m = MustParseMessage("PONG :t\x00e\rst")
+	assert.Equal(t, m.Param(0), "test")
+	assert.Equal(t, m.Param(-1), "")
+	assert.Equal(t, m.Param(2), "")
 }
 
 func TestMessageTrailing(t *testing.T) {


### PR DESCRIPTION
NUL, CR and LF are explicitly forbidden in IRC messages:
https://datatracker.ietf.org/doc/html/rfc1459#section-2.3.1
https://datatracker.ietf.org/doc/html/rfc2812#section-2.3.1
https://modern.ircdocs.horse/#messages

However, since they are most likely to appear in PRIVMSG/NOTICE payload,
it should be fine to ignore them (instead of returning an error).