### PR TITLE
Return context error in Client.RunContext()

### DIFF
--- a/client.go
+++ b/client.go
@@ -354,6 +354,7 @@ func (c *Client) RunContext(ctx context.Context) error {
 	select {
 	case err = <-c.errChan:
 	case <-ctx.Done():
+		err = ctx.Err()
 	}
 
 	close(exiting)


### PR DESCRIPTION
If the context deadline has exceeded for instance, callers would expect Client.RunContext() to return context.DeadlineExceeded.